### PR TITLE
increment version number to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "raiden-synapse-modules"
-version = "1.0.0rc4"
+version = "0.1.4"
 description = "synapse modules for the Raiden network"
 authors = ["Brainbot Labs Est. <contact@brainbot.li>"]
 license = "MIT"


### PR DESCRIPTION
Please note that although we have used the version `1.0.0` for the release candidates, it has been decided that this is not a breaking change for this module. Thereby we only bump by a minor version.